### PR TITLE
update version in the header for ota_pal.h

### DIFF
--- a/ota_pal.h
+++ b/ota_pal.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS V202012.00
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS V202107.00
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Update header with correct FreeRTOS version and avoid confusion: FreeRTOS V202107.00, which is the OTA PAL for OTA v3.0.0
Reference: https://github.com/aws/amazon-freertos/blob/202107.00/vendors/vendor/boards/board/ports/ota_pal_for_aws/ota_pal.h