### PR TITLE
Write image data more times if FWU MAX BLOCK SIZE is not big enough

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project ports the FreeRTOS OTA PAL based on PSA API.
 
 PSA is Platform Security Architecture which is initiated by Arm. Please get the details from this [link](https://www.arm.com/why-arm/architecture/platform-security-architecture).
 
-In general, this porting maps the FreeRTOS OTA PAL APIs to PSA Firmware Update and Crypto APIs. It follows the PSA Firmware Update API 0.7 and PSA Cryptography API V1.0 beta3. The process of image write, image verification and image activation are protected by the PSA secure service.
+In general, this porting maps the FreeRTOS OTA PAL APIs to PSA Firmware Update and Crypto APIs. It follows the PSA Firmware Update API 0.7 and PSA Cryptography API v1.0 beta3. The process of image write, image verification and image activation are protected by the PSA secure service.
 
 # License
 
@@ -27,6 +27,8 @@ Unless stated otherwise, the software is provided under the [MIT License](https:
 ## Integrate FreeRTOS project with Trusted Firmware-M (TF-M)
 
 [TF-M](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/) is a PSA implementation. It implements the PSA Firmware Framework API and developer API such as Secure Storage, Cryptography, Initial Attestation, etc. Refer to [PSA website](https://developer.arm.com/architectures/security-architectures/platform-security-architecture) for more details.
+
+This version of FreeRTOS OTA PAL is supported by TF-M [v1.4.0](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tag/?h=TF-Mv1.4.0) & [v1.5.0](https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tag/?h=TF-Mv1.5.0).
 
 Please follow the [Build instructions](https://tf-m-user-guide.trustedfirmware.org/docs/technical_references/instructions/tfm_build_instruction.html) of TF-M to build the secure side image for your platform.
 

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -1,6 +1,6 @@
 /*
- * FreeRTOS V202012.00
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * FreeRTOS V202107.00
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Chances are that ulBlockSize is bigger than PSA_FWU_MAX_BLOCK_SIZE.
It is needed to call psa_fwu_write for more times to make sure all
data in the block are completely written in this case.

Signed-off-by: Xinyu Zhang <xinyu.zhang@arm.com>
Change-Id: I504080d7144e7542ce81bbca457568b91606e745