### PR TITLE
Update ota-pal-psa for STM32U5.

### DIFF
--- a/ota_pal.c
+++ b/ota_pal.c
@@ -372,7 +372,7 @@ static OtaPalStatus_t otaPal_CheckSignature( OtaFileContext_t * const pFileConte
     
     ucSigBuffer = &ucECDSARAWSignature;
     usSigLength = ECDSA_SHA256_RAW_SIGNATURE_LENGTH;
-#endif /* defined( OTA_PAL_CODE_SIGNING_ALGO ) && ( OTA_PAL_CODE_SIGNING_ALGO == OTA_PAL_CODE_SIGNING_RSA ) */
+#endif /* !defined( OTA_PAL_SIGNATURE_ASN1_DER_FORMAT ) */
 
     uxStatus = psa_get_key_attributes( xOTACodeVerifyKeyHandle, &xKeyAttribute );
     if( uxStatus != PSA_SUCCESS )

--- a/ota_pal.c
+++ b/ota_pal.c
@@ -375,11 +375,11 @@ static bool prvCheckVersion( psa_image_info_t * pActiveVersion,  psa_image_info_
 
     xActiveFirmwareVersion.u.x.major = pActiveVersion->version.iv_major;
     xActiveFirmwareVersion.u.x.minor = pActiveVersion->version.iv_minor;
-    xActiveFirmwareVersion.u.x.build = (uint16_t)pActiveVersion->version.iv_build_num;
+    xActiveFirmwareVersion.u.x.build = (uint16_t)pActiveVersion->version.iv_revision;
 
     xStageFirmwareVersion.u.x.major = pStageVersion->version.iv_major;
     xStageFirmwareVersion.u.x.minor = pStageVersion->version.iv_minor;
-    xStageFirmwareVersion.u.x.build = (uint16_t)pStageVersion->version.iv_build_num;
+    xStageFirmwareVersion.u.x.build = (uint16_t)pStageVersion->version.iv_revision;
 
     if( xActiveFirmwareVersion.u.unsignedVersion32 > xStageFirmwareVersion.u.unsignedVersion32 )
     {
@@ -412,10 +412,10 @@ bool OtaPal_ImageVersionCheck( uint32_t ulImageType )
                         ulImageType,
                         xStageImageInfo.version.iv_major,
                         xStageImageInfo.version.iv_minor,
-                        xStageImageInfo.version.iv_build_num,
+                        xStageImageInfo.version.iv_revision,
                         xActiveImageInfo.version.iv_major,
                         xActiveImageInfo.version.iv_minor,
-                        xActiveImageInfo.version.iv_build_num );
+                        xActiveImageInfo.version.iv_revision );
             }
             else
             {
@@ -423,10 +423,10 @@ bool OtaPal_ImageVersionCheck( uint32_t ulImageType )
                         ulImageType,
                         xStageImageInfo.version.iv_major,
                         xStageImageInfo.version.iv_minor,
-                        xStageImageInfo.version.iv_build_num,
+                        xStageImageInfo.version.iv_revision,
                         xActiveImageInfo.version.iv_major,
                         xActiveImageInfo.version.iv_minor,
-                        xActiveImageInfo.version.iv_build_num );
+                        xActiveImageInfo.version.iv_revision );
             }
         }
     }
@@ -449,7 +449,7 @@ bool otaPal_GetImageVersion( AppVersion32_t * pSecureVersion, AppVersion32_t * p
     {
         pSecureVersion->u.x.major = xImageInfo.version.iv_major;
         pSecureVersion->u.x.minor = xImageInfo.version.iv_minor;
-        pSecureVersion->u.x.build = (uint16_t)xImageInfo.version.iv_build_num;
+        pSecureVersion->u.x.build = (uint16_t)xImageInfo.version.iv_revision;
         xStatus = true;
     }
     else
@@ -465,7 +465,7 @@ bool otaPal_GetImageVersion( AppVersion32_t * pSecureVersion, AppVersion32_t * p
         {
             pNonSecureVersion->u.x.major = xImageInfo.version.iv_major;
             pNonSecureVersion->u.x.minor = xImageInfo.version.iv_minor;
-            pNonSecureVersion->u.x.build = (uint16_t)xImageInfo.version.iv_build_num;
+            pNonSecureVersion->u.x.build = (uint16_t)xImageInfo.version.iv_revision;
         }
         else
         {

--- a/ota_pal.c
+++ b/ota_pal.c
@@ -40,6 +40,9 @@
 
 #include "logging.h"
 
+/* To provide appFirmwareVersion for OTA library. */
+#include "ota_appversion32.h"
+
 /* OTA PAL Port include. */
 #include "ota_pal.h"
 
@@ -357,7 +360,7 @@ static OtaPalStatus_t otaPal_CheckSignature( OtaFileContext_t * const pFileConte
         return OTA_PAL_COMBINE_ERR( OtaPalSignatureCheckFailed, OTA_PAL_SUB_ERR( uxStatus ) );
     }
 
-#if defined( OTA_PAL_CODE_SIGNING_ALGO ) && ( OTA_PAL_CODE_SIGNING_ALGO == OTA_PAL_CODE_SIGNING_RSA )
+#if !defined( OTA_PAL_SIGNATURE_ASN1_DER_FORMAT )
     ucSigBuffer = &pFileContext->pSignature->data;
     usSigLength = pFileContext->pSignature->size;
 #else

--- a/ota_pal.c
+++ b/ota_pal.c
@@ -313,8 +313,6 @@ static OtaPalStatus_t otaPal_CheckSignature( OtaFileContext_t * const pFileConte
     psa_image_info_t xImageInfo = { 0 };
     psa_status_t uxStatus;
     psa_key_attributes_t xKeyAttribute = PSA_KEY_ATTRIBUTES_INIT;
-    psa_algorithm_t xKeyAlgorithm = 0;
-    bool xDecodeStatus;
 
     uxStatus = psa_fwu_query( xOTAImageID, &xImageInfo );
     if( uxStatus != PSA_SUCCESS )
@@ -328,18 +326,8 @@ static OtaPalStatus_t otaPal_CheckSignature( OtaFileContext_t * const pFileConte
     	return OTA_PAL_COMBINE_ERR( OtaPalSignatureCheckFailed, 0 );
     }
 
-
-    uxStatus = psa_get_key_attributes( xOTACodeVerifyKeyHandle, &xKeyAttribute );
-    if( uxStatus != PSA_SUCCESS )
-    {
-        return OTA_PAL_COMBINE_ERR( OtaPalSignatureCheckFailed, OTA_PAL_SUB_ERR( uxStatus ) );
-    }
-
-
-
-    xKeyAlgorithm = psa_get_key_algorithm( &xKeyAttribute );
     uxStatus = psa_verify_hash( xOTACodeVerifyKeyHandle,
-                                xKeyAlgorithm,
+                                PSA_ALG_ECDSA( PSA_ALG_SHA_256 ),
                                 ( const uint8_t * )xImageInfo.digest,
                                 ( size_t )PSA_FWU_MAX_DIGEST_SIZE,
 								ucECDSARAWSignature,

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -233,25 +233,4 @@ OtaPalImageState_t otaPal_GetPlatformImageState( OtaFileContext_t * const pFileC
  *         error codes and your specific PAL implementation for the sub error code.
  */
 OtaPalStatus_t otaPal_ResetDevice( OtaFileContext_t * const pFileContext );
-
-/**
- * @brief Get Secure and Non Secure Image versions.
- *
- * @param[out] pSecureVersion Pointer to secure version struct.
- * @param[out] pNonSecureVersion Pointer to non-secure version struct.
- *
- * @return true if version was fetched successfully.
- *
- */
-bool otaPal_GetImageVersion( AppVersion32_t * pSecureVersion, AppVersion32_t * pNonSecureVersion );
-
-/**
- * @brief Checks versions of an image type for rollback protection.
- *
- * @param[in] ulImageType Image Type for which the version needs to be checked.
-
- * @return true if the version is higher than previous version. false otherwise.
- *
- */
-bool OtaPal_ImageVersionCheck( uint32_t ulImageType );
 #endif /* ifndef OTA_PAL_H_ */

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -32,6 +32,7 @@
 #define OTA_PAL_H_
 
 #include "ota.h"
+#include "ota_appversion32.h"
 
 /**
  * @brief Abort an OTA transfer.
@@ -226,4 +227,24 @@ OtaPalImageState_t otaPal_GetPlatformImageState( OtaFileContext_t * const pFileC
  */
 OtaPalStatus_t otaPal_ResetDevice( OtaFileContext_t * const pFileContext );
 
+/**
+ * @brief Get Secure and Non Secure Image versions.
+ *
+ * @param[out] pSecureVersion Pointer to secure version struct.
+ * @param[out] pNonSecureVersion Pointer to non-secure version struct.
+ *
+ * @return true if version was fetched successfully.
+ *
+ */
+bool otaPal_GetImageVersion( AppVersion32_t * pSecureVersion, AppVersion32_t * pNonSecureVersion );
+
+/**
+ * @brief Checks versions of an image type for rollback protection.
+ *
+ * @param[in] ulImageType Image Type for which the version needs to be checked.
+
+ * @return true if the version is higher than previous version. false otherwise.
+ *
+ */
+bool OtaPal_ImageVersionCheck( uint32_t ulImageType );
 #endif /* ifndef OTA_PAL_H_ */

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -34,6 +34,13 @@
 #include "ota.h"
 #include "ota_appversion32.h"
 
+/* OTA PAL configurations. */
+#define OTA_PAL_CODE_SIGNING_RSA    ( 0 )
+#define OTA_PAL_CODE_SIGNING_ECDSA  ( 1 )
+
+/* Choose code signing algorithm. */
+#define OTA_PAL_CODE_SIGNING_ALGO   ( OTA_PAL_CODE_SIGNING_ECDSA )
+
 /**
  * @brief Abort an OTA transfer.
  *

--- a/ota_pal.h
+++ b/ota_pal.h
@@ -32,7 +32,6 @@
 #define OTA_PAL_H_
 
 #include "ota.h"
-#include "ota_appversion32.h"
 
 /* OTA PAL configurations. */
 #define OTA_PAL_CODE_SIGNING_RSA    ( 0 )
@@ -40,6 +39,9 @@
 
 /* Choose code signing algorithm. */
 #define OTA_PAL_CODE_SIGNING_ALGO   ( OTA_PAL_CODE_SIGNING_ECDSA )
+
+/* Enable to convert ASN1/DER signature to raw data. */
+#define OTA_PAL_SIGNATURE_ASN1_DER_FORMAT
 
 /**
  * @brief Abort an OTA transfer.


### PR DESCRIPTION
To provide [golden reference on STM32U5](https://github.com/FreeRTOS/iot-reference-stm32u5), we updated the ota-pal-psa after testing. Changes inclue:
- Support ECDSA SHA256 signing as default
- Use SHA256 ECDSA hash for signature validation
- Version validation
- Check all image states if filepath is not provided
- Update otaPal_Abort and otaPal_SetPlatformImageState to pass OTA_PAL qualification test